### PR TITLE
Change `set-spawn` to `setspawnmod` in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Mac OS only:
 - `sodiummac`
 
 Set seed categories only:
-- `set-spawn`
+- `setspawnmod`
 - `chunkcacher`
 
 For developers, these conditions can be found in the `conditional-mods.json` file found in the root of this repository.


### PR DESCRIPTION
Something I noticed in the readme, set spawn's mod id in the readme does not match the one in `conditional-mods.json`, that's all the PR fixes.