### PR TITLE
Update update-legal-builds.yml to be manually triggered and create a PR instead

### DIFF
--- a/.github/workflows/update-legal-builds.yml
+++ b/.github/workflows/update-legal-builds.yml
@@ -24,7 +24,7 @@ jobs:
           git commit -m "update hashes" || echo "No changes to commit"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "update hashes"
           title: "Update legal builds"

--- a/.github/workflows/update-legal-builds.yml
+++ b/.github/workflows/update-legal-builds.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "update hashes"
           title: "Update legal builds"
           body: "Automated update of legal builds from get_hashes.py"
           branch: "legal-builds-update"

--- a/.github/workflows/update-legal-builds.yml
+++ b/.github/workflows/update-legal-builds.yml
@@ -1,25 +1,32 @@
 name: update legal builds
+
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - legal-mods/**
+  workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: build
+
+      - name: Run update script and commit changes
         run: |
           python get_hashes.py
           git add legal-builds.csv
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "update hashes"
-          git push origin ${{ github.ref_name }}
+          # Allow the commit to fail if there are no changes
+          git commit -m "update hashes" || echo "No changes to commit"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "update hashes"
+          title: "Update legal builds"
+          body: "Automated update of legal builds from get_hashes.py"
+          branch: "legal-builds-update"


### PR DESCRIPTION
Resolves #127

Example: https://github.com/DuncanRuns/illegal-mods/pull/1

Got a robot to make this update for me, looks fine.
No PR is created in case there are no changes to commit, which we should never run into anyway if we only run it after mod updates.