### PR TITLE
External Mods as of Sept 7 2026

### DIFF
--- a/legal-mods/krypton/26.2/krypton-0.3.1.json
+++ b/legal-mods/krypton/26.2/krypton-0.3.1.json
@@ -1,0 +1,4 @@
+{
+  "link": "https://cdn.modrinth.com/data/fQEb0iXm/versions/5WeL0Nkz/krypton-0.3.1.jar",
+  "hash": "b8d9af34cd0050493afb8a6232cb8f785daa9d8887b7045f6e6a53c6bb9b5ffc4318fd9b0347a940eacfeba4773f10cb80ae0be1e79ce4c1888f96eda21e564e"
+}

--- a/legal-mods/lithium/26.1-26.1.2/lithium-fabric-0.24.6+mc26.1.2.json
+++ b/legal-mods/lithium/26.1-26.1.2/lithium-fabric-0.24.6+mc26.1.2.json
@@ -1,4 +1,0 @@
-{
-  "link": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/fQBdPR1m/lithium-fabric-0.24.6%2Bmc26.1.2.jar",
-  "hash": "fac351f5b6150889b9355a01889c35b5798147d4bedb291594a590a2d41909eb8dc494ef0051317bf55886f2fc7fe134abbe2e755098df38473edb2bf43357e9"
-}

--- a/legal-mods/lithium/26.1-26.1.2/lithium-fabric-0.24.7+mc26.1.2.json
+++ b/legal-mods/lithium/26.1-26.1.2/lithium-fabric-0.24.7+mc26.1.2.json
@@ -1,0 +1,4 @@
+{
+  "link": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/Oqq8TOAV/lithium-fabric-0.24.7%2Bmc26.1.2.jar",
+  "hash": "37240bdbf93c19fdc6aa632d89223639f0ef9d923ee1793b33d624946b0482cc972834049ed07d71db3494e16c9de68e755937aac7c4ac5d7291bd38c1425899"
+}

--- a/legal-mods/lithium/26.2/lithium-fabric-0.25.2+mc26.2.json
+++ b/legal-mods/lithium/26.2/lithium-fabric-0.25.2+mc26.2.json
@@ -1,4 +1,0 @@
-{
-  "link": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/UPNexAfy/lithium-fabric-0.25.2%2Bmc26.2.jar",
-  "hash": "db676376c05b7e912cdae5aad9e51f125adc1554ae2b204599ccb598751921aedbac98e97b9cba0333b6b52488c6b75c915a7dbd50436f97800387fe1aad1c50"
-}

--- a/legal-mods/lithium/26.2/lithium-fabric-0.25.3+mc26.2.json
+++ b/legal-mods/lithium/26.2/lithium-fabric-0.25.3+mc26.2.json
@@ -1,0 +1,4 @@
+{
+  "link": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/f7vZ0VWU/lithium-fabric-0.25.3%2Bmc26.2.jar",
+  "hash": "148b638f3c6229fbaf487120a2344a0af5e411a5aa6533d5db9d75da0a8c0d8304f63eb4cca13f4d03b2c9b4c23d559dd74c1d832422ef8a3087bd005e62a8bd"
+}

--- a/legal-mods/sodium/1.21.1/sodium-fabric-0.8.12+mc1.21.1.json
+++ b/legal-mods/sodium/1.21.1/sodium-fabric-0.8.12+mc1.21.1.json
@@ -1,4 +1,0 @@
-{
-  "link": "https://cdn.modrinth.com/data/AANobbMI/versions/KIRFiWG4/sodium-fabric-0.8.12%2Bmc1.21.1.jar",
-  "hash": "8afe411eec65a9f677611ed6390ce656e5a3572f9be473e5dca51ae882a9426a547cd2e8c793278577bb14c17e48158030b11753108926ef33698614bd94ed7f"
-}

--- a/legal-mods/sodium/1.21.1/sodium-fabric-0.8.13+mc1.21.1.json
+++ b/legal-mods/sodium/1.21.1/sodium-fabric-0.8.13+mc1.21.1.json
@@ -1,0 +1,4 @@
+{
+  "link": "https://cdn.modrinth.com/data/AANobbMI/versions/SMxNOGZ6/sodium-fabric-0.8.13%2Bmc1.21.1.jar",
+  "hash": "8614a374593698069a80ac74de8cd9c28f3928d16819a0e0d6320b538e823f7e54e8be06d5ea5a9c268beb0e02073209d1f831a02dede851588b972367680853"
+}

--- a/legal-mods/sodium/1.21.11/sodium-fabric-0.8.13+mc1.21.11.json
+++ b/legal-mods/sodium/1.21.11/sodium-fabric-0.8.13+mc1.21.11.json
@@ -1,4 +1,0 @@
-{
-  "link": "https://cdn.modrinth.com/data/AANobbMI/versions/Ny3XyYle/sodium-fabric-0.8.13%2Bmc1.21.11.jar",
-  "hash": "6e96ed8e547ea7a8c32273a1152cf02cb26246b3a605c4ed782dc84a52cfbc16d07313c2ea7e1e5e5377784e3e9cbc599b0f2dd139d9fe4c9cbe3381f0dc30f0"
-}

--- a/legal-mods/sodium/1.21.11/sodium-fabric-0.8.14+mc1.21.11.json
+++ b/legal-mods/sodium/1.21.11/sodium-fabric-0.8.14+mc1.21.11.json
@@ -1,0 +1,4 @@
+{
+  "link": "https://cdn.modrinth.com/data/AANobbMI/versions/rkdTcxoT/sodium-fabric-0.8.14%2Bmc1.21.11.jar",
+  "hash": "04c43f9e8534b87a52c42ffd51b0e344d4ef92dc9cc52da33d13af6a18bf74b05380d2027f1e0db982698d0aff274c42741c1e21b313b0cd75ed3af005fc98d9"
+}


### PR DESCRIPTION
Short notes:
```
- (**1.21.1**) Sodium 0.8.13: External update, various minor fixes. ([JellySquid](<https://ko-fi.com/jellysquid_>))
- (**1.21.11**) Sodium 0.8.14: External update, various minor fixes. ([JellySquid](<https://ko-fi.com/jellysquid_>))
- (**26.1-26.1.2**) Lithium 0.24.7: External update, various minor fixes and new optimizations. ([2No2Name](<https://www.patreon.com/2No2Name>))
- (**26.2**) Lithium 0.25.3: External update, various minor fixes and new optimizations. ([2No2Name](<https://www.patreon.com/2No2Name>))
- (**26.2**) Krypton 0.3.1: External update, port to 26.2. ([astei](<https://github.com/sponsors/astei>))
```